### PR TITLE
Fix createReleaseTag ordering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,12 +96,14 @@ githubRelease {
    body = layout.projectDirectory.file('release/changes.md').asFile.text.trim()
 }
 
-tasks.register('createReleaseTag', CreateGitTag) {
+def createReleaseTag = tasks.register('createReleaseTag', CreateGitTag) {
+    // This makes sure the tag is created only after building and publishing the plugin succeeds
+    mustRunAfter('publishPlugins')
     tagName = gitReleaseTag()
 }
 
-tasks.named('githubRelease').configure {
-    dependsOn('createReleaseTag')
+tasks.named('githubRelease') {
+    dependsOn(createReleaseTag)
 }
 
 tasks.withType(Sign).configureEach {


### PR DESCRIPTION
This should ensure `createReleaseTag` is executed after `publishPlugins` whenever `publishPlugins githubRelease` is requested.