### PR TITLE
Set version to String

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ def releaseVersion = releaseVersion()
 def releaseNotes = releaseNotes()
 
 group = 'org.gradle'
-version = releaseVersion
+version = releaseVersion.get()
 description = 'A Gradle plugin that detects and updates Gradle and Maven wrappers to the latest Gradle and Maven version.'
 
 repositories {


### PR DESCRIPTION
Setting version to `Property<String>` causes incorrect jar file names and incorrect version in pom files

### Tests
1. Published wrapper-upgrade-gradle-plugin to maven local and successfully resolved it as a dependency ([build scan](https://ge.solutions-team.gradle.com/s/tjjdviwuofg3u/build-dependencies?focusedDependency=WzAsMCw3LFswLDAsWzQsN11dXQ&toggled=W1swXSxbMCwwXSxbMCwwLFs0XV1d))
2. Ran a `githubRelease` dry run
```
:githubRelease [This task is a dry run. All API calls that would modify the repo are disabled. API calls that access the repo information are not disabled. Use this to show what actions would be executed.]
:githubRelease [CHECKING FOR PREVIOUS RELEASE]
:githubRelease [CREATING NEW RELEASE 
{
    tag_name               = v0.11.2
    target_commitish       = main
    name                   = 0.11.2
    generate_release_notes = false
    body                   = 
        
    draft                  = false
    prerelease             = false
}]
```