### PR TITLE
Disable toolchain provisioning in CI

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
       - name: Build with Gradle
-        run: ./gradlew build -x signPluginMavenPublication -i -PtestGradleVersion=${{ matrix.gradle-version }}
+        run: ./gradlew build -x signPluginMavenPublication -i -PtestGradleVersion=${{ matrix.gradle-version }}  -Porg.gradle.java.installations.auto-download=false
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
       - name: Upgrade Wrappers
-        run: ./gradlew clean upgradeGradleWrapperAll --continue
+        run: ./gradlew clean upgradeGradleWrapperAll --continue -Porg.gradle.java.installations.auto-download=false
         env:
           WRAPPER_UPGRADE_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}


### PR DESCRIPTION
Auto-provisioning can come with a tradeoff of slower builds when a toolchain is auto-provisioned. For our CI builds, we should disable auto-provisioning to make sure we are not taking a performance hit by provisioning toolchains on every build.