### PR TITLE
Do not execute tests using Gradle versions < 7.6.1

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-            gradle-version: [ '6.0.1', '6.9.4', '7.0.2', '7.6.1', '8.0.2', '8.1.1' ]
+            gradle-version: [ '7.6.1', '8.0.2', '8.1.1' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Jackson versions 2.15.0 and later are not compatible with these older versions of Gradle