### PR TITLE
Add workflow to submit GH dependency graph

### DIFF
--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -1,0 +1,26 @@
+name: Submit GitHub Dependency Graph
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  
+permissions: write-all
+
+jobs:
+  generate-and-submit-graph:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 8
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2    
+    - name: Generate dependency graph
+      uses: gradle/gradle-build-action/actions/dependency-graph-generate@v2
+      env:
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+    - name: Submit dependency graph
+      uses: gradle/gradle-build-action/actions/dependency-graph-submit@v2


### PR DESCRIPTION
This workflow will calculate and submit a GitHub Dependency Graph for any change to the 'main' branch. This allows GitHub to display the dependencies in the "Insights" tab, and to inspect all dependencies for security vulnerabilities.