### PR TITLE
Add NOTICE file and include it and LICENSE in the assembled JAR file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,13 @@ tasks.withType(Test).configureEach {
     buildScan.value(identityPath.path + "#gradleVersion", testGradleVersion)
 }
 
+tasks.withType(Jar).configureEach {
+    into(".") {
+        from(layout.projectDirectory.file("LICENSE"))
+        from(layout.projectDirectory.dir("release/distribution"))
+    }
+}
+
 gradlePlugin {
     website = "https://github.com/gradle/wrapper-upgrade-gradle-plugin/"
     vcsUrl = "https://github.com/gradle/wrapper-upgrade-gradle-plugin.git"

--- a/release/distribution/NOTICE
+++ b/release/distribution/NOTICE
@@ -1,0 +1,72 @@
+The following copyright statements and licenses apply to various third party open
+source software packages (or portions thereof) that are distributed with
+this content.
+
+TABLE OF CONTENTS
+=================
+
+The following is a listing of the open source components detailed in this
+document.  This list is provided for your convenience; please read further if
+you wish to review the copyright notice(s) and the full text of the license
+associated with each component.
+
+
+**SECTION 1: Apache License, V2.0**
+  * Jackson Core
+    * com.fasterxml.jackson.core:jackson-core
+  * Jackson Dataformat XML
+    * com.fasterxml.jackson.dataformat:jackson-dataformat-xml
+
+**SECTION 2: MIT License**
+  * Java API for GitHub
+    * org.kohsuke:github-api
+
+SECTION 1: Apache License, V2.0
+================================
+
+Jackson Core
+Jackson Dataformat XML
+-----------------------------------
+
+Copyright 2023 The Apache Software Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SECTION 2: MIT License
+================================
+
+Java API for GitHub
+-----------------------------------
+
+Copyright (c) 2011- Kohsuke Kawaguchi and other contributors
+
+ Permission is hereby granted, free of charge, to any person
+ obtaining a copy of this software and associated documentation
+ files (the "Software"), to deal in the Software without
+ restriction, including without limitation the rights to use,
+ copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following
+ conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This PR adds a NOTICE file to the root of the project. The NOTICE file includes the licenses of all runtime dependencies.

Both the NOTICE and LICENSE files are now included in the assembled JAR.