### PR TITLE
Support for custom labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ wrapperUpgrade {
 | `baseBranch`                 | The git branch to checkout and that the pull request will target                                                                                                 |
 | `options.gitCommitExtraArgs` | List of additional git commit arguments                                                                                                                          |
 | `options.allowPreRelease`    | Boolean: true will get the latest Maven/Gradle version even if it's a pre-release. Default is false.                                                             |
+| `options.labels`             | Optional list of label (names) that will be added to the PR.                                                                                                     |
 
 ## License
 

--- a/src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java
+++ b/src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java
@@ -167,6 +167,10 @@ public abstract class UpgradeWrapper extends DefaultTask {
     private void gitCreatePr(Params params, String prTitle, String prBody) throws IOException {
         if (!isDryRun()) {
             GHPullRequest pr = params.gitHub.getRepository(params.repository).createPullRequest(prTitle, params.prBranch, params.baseBranch, prBody);
+            List<String> labels = upgrade.getOptions().getLabels().get();
+            if (!labels.isEmpty()) {
+                pr.addLabels(labels.toArray(new String[0]));
+            }
             getLogger().lifecycle(String.format("PR '%s' created at %s to upgrade %s Wrapper to %s for project '%s'",
                 params.prBranch, pr.getHtmlUrl(), buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version, params.project));
         } else {

--- a/src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java
+++ b/src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java
@@ -51,11 +51,13 @@ public abstract class WrapperUpgradeDomainObject {
 
         private final ListProperty<String> gitCommitExtraArgs;
         private final Property<Boolean> allowPreRelease;
+        private final ListProperty<String> labels;
 
         @Inject
         public Options(ObjectFactory objects) {
             this.gitCommitExtraArgs = objects.listProperty(String.class);
             this.allowPreRelease = objects.property(Boolean.class);
+            this.labels = objects.listProperty(String.class);
         }
 
         public ListProperty<String> getGitCommitExtraArgs() {
@@ -64,6 +66,10 @@ public abstract class WrapperUpgradeDomainObject {
 
         public Property<Boolean> getAllowPreRelease() {
             return allowPreRelease;
+        }
+
+         public ListProperty<String> getLabels() {
+            return labels;
         }
     }
 

--- a/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
@@ -49,6 +49,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
                         dir = 'samples/gradle'
                         options {
                             allowPreRelease = ${allowPreRelease}
+                            labels = ["dependencies", "java"]
                         }
                     }
                 }

--- a/src/test/groovy/org/gradle/wrapperupgrade/MavenWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/MavenWrapperUpgradePluginFuncTest.groovy
@@ -43,6 +43,7 @@ wrapperUpgrade {
             dir = 'samples/maven'
             options {
                 allowPreRelease = ${allowPreRelease}
+                labels = ["dependencies", "java"]
             }
         }
     }


### PR DESCRIPTION
Fixes parts of #215 

Only for labels 😅 

## AI summary
This pull request introduces new functionality to add labels to pull requests created by the wrapper upgrade process. The changes include updates to the `Options` class to support labels, modifications to the pull request creation logic to apply these labels, and test updates to verify the new functionality.

Key changes:

### Adding support for labels in pull requests:

* [`src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java`](diffhunk://#diff-a33cf858e92eb494feb5f7d04cf517eaf3f6136ce988f6cee599dc31b2598be6R170-R173): Modified the `gitCreatePr` method to add labels to the pull request if they are specified in the options.
* [`src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java`](diffhunk://#diff-a9201ae60d8b212fc5004aaad8410d5e75255635ee8e79a83aa0d00505a62a6cR54-R60): Added a new `labels` property to the `Options` class and provided a getter method for it. [[1]](diffhunk://#diff-a9201ae60d8b212fc5004aaad8410d5e75255635ee8e79a83aa0d00505a62a6cR54-R60) [[2]](diffhunk://#diff-a9201ae60d8b212fc5004aaad8410d5e75255635ee8e79a83aa0d00505a62a6cR70-R73)

### Test updates:

* [`src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy`](diffhunk://#diff-cc651b989a629859f563d6d1ee2d0c205a953b80c053c58f89a09975f39064bdR52): Updated the functional test to include labels in the options for the wrapper upgrade.
