### PR TITLE
Handle existing upgrade PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,23 +115,23 @@ wrapperUpgrade {
                 gitCommitExtraArgs = [...]
                 allowPreRelease = true
                 labels = ['dependencies']
-                ignoreExistingClosedPr = true
+                ignoreClosedPRs = true
             }
         }
     }
 }
 ```
 
-| Field                            | description                                                                                                                                                      |
-|:---------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`                           | A name identifying the upgrade, it can be different from the project name, for example when you need to upgrade multiple gradle projects in the same git project |
-| `repo`                           | The GitHub repository to clone, format 'organization/project`                                                                                                    |
-| `dir`                            | The directory inside the project base directory to run the gradle or maven upgrade in                                                                            |
-| `baseBranch`                     | The git branch to checkout and that the pull request will target                                                                                                 |
-| `options.gitCommitExtraArgs`     | List of additional git commit arguments                                                                                                                          |
-| `options.allowPreRelease`        | Boolean: true will get the latest Maven/Gradle version even if it's a pre-release. Default is false.                                                             |
-| `options.labels`                 | Optional list of label (names) that will be added to the PR.                                                                                                     |
-| `options.ignoreExistingClosedPr` | Boolean: true will recreate the PR if a closed PR with the same branch name exists. false will not create the PR. Default is false.                              |
+| Field                        | description                                                                                                                                                      |
+|:-----------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                       | A name identifying the upgrade, it can be different from the project name, for example when you need to upgrade multiple gradle projects in the same git project |
+| `repo`                       | The GitHub repository to clone, format 'organization/project`                                                                                                    |
+| `dir`                        | The directory inside the project base directory to run the gradle or maven upgrade in                                                                            |
+| `baseBranch`                 | The git branch to checkout and that the pull request will target                                                                                                 |
+| `options.gitCommitExtraArgs` | List of additional git commit arguments                                                                                                                          |
+| `options.allowPreRelease`    | Boolean: true will get the latest Maven/Gradle version even if it's a pre-release. Default is false.                                                             |
+| `options.labels`             | Optional list of label (names) that will be added to the PR.                                                                                                     |
+| `options.ignoreClosedPRs`    | Boolean: true will recreate the PR if a closed PR with the same branch name exists. false will not create the PR. Default is false.                              |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -115,23 +115,23 @@ wrapperUpgrade {
                 gitCommitExtraArgs = [...]
                 allowPreRelease = true
                 labels = ['dependencies']
-                ignoreClosedPullRequests = true
+                recreateClosedPullRequests = true
             }
         }
     }
 }
 ```
 
-| Field                              | description                                                                                                                                                             |
-|:-----------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`                             | A name identifying the upgrade, it can be different from the project name, for example when you need to upgrade multiple gradle projects in the same git project        |
-| `repo`                             | The GitHub repository to clone, format 'organization/project`                                                                                                           |
-| `dir`                              | The directory inside the project base directory to run the gradle or maven upgrade in                                                                                   |
-| `baseBranch`                       | The git branch to checkout and that the pull request will target                                                                                                        |
-| `options.gitCommitExtraArgs`       | List of additional git commit arguments                                                                                                                                 |
-| `options.allowPreRelease`          | Boolean: `true` will get the latest Maven/Gradle version even if it's a pre-release. Default is `false`.                                                                |
-| `options.labels`                   | Optional list of label (names) that will be added to the pull request.                                                                                                  |
-| `options.ignoreClosedPullRequests` | Boolean: `true` will recreate the pull request if a closed pull request with the same branch name exists. `false` will not create the pull request. Default is `false`. |
+| Field                                | description                                                                                                                                                               |
+|:-------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                               | A name identifying the upgrade, it can be different from the project name, for example when you need to upgrade multiple gradle projects in the same git project          |
+| `repo`                               | The GitHub repository to clone, format 'organization/project`                                                                                                             |
+| `dir`                                | The directory inside the project base directory to run the gradle or maven upgrade in                                                                                     |
+| `baseBranch`                         | The git branch to checkout and that the pull request will target                                                                                                          |
+| `options.gitCommitExtraArgs`         | List of additional git commit arguments                                                                                                                                   |
+| `options.allowPreRelease`            | Boolean: `true` will get the latest Maven/Gradle version even if it's a pre-release. Default is `false`.                                                                  |
+| `options.labels`                     | Optional list of label (names) that will be added to the pull request.                                                                                                    |
+| `options.recreateClosedPullRequests` | Boolean: `true` will recreate the pull request if a closed pull request with the same branch name exists. `false` will not recreate the pull request. Default is `false`. |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -115,23 +115,23 @@ wrapperUpgrade {
                 gitCommitExtraArgs = [...]
                 allowPreRelease = true
                 labels = ['dependencies']
-                ignoreClosedPRs = true
+                ignoreClosedPullRequests = true
             }
         }
     }
 }
 ```
 
-| Field                        | description                                                                                                                                                      |
-|:-----------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`                       | A name identifying the upgrade, it can be different from the project name, for example when you need to upgrade multiple gradle projects in the same git project |
-| `repo`                       | The GitHub repository to clone, format 'organization/project`                                                                                                    |
-| `dir`                        | The directory inside the project base directory to run the gradle or maven upgrade in                                                                            |
-| `baseBranch`                 | The git branch to checkout and that the pull request will target                                                                                                 |
-| `options.gitCommitExtraArgs` | List of additional git commit arguments                                                                                                                          |
-| `options.allowPreRelease`    | Boolean: true will get the latest Maven/Gradle version even if it's a pre-release. Default is false.                                                             |
-| `options.labels`             | Optional list of label (names) that will be added to the PR.                                                                                                     |
-| `options.ignoreClosedPRs`    | Boolean: true will recreate the PR if a closed PR with the same branch name exists. false will not create the PR. Default is false.                              |
+| Field                              | description                                                                                                                                                             |
+|:-----------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                             | A name identifying the upgrade, it can be different from the project name, for example when you need to upgrade multiple gradle projects in the same git project        |
+| `repo`                             | The GitHub repository to clone, format 'organization/project`                                                                                                           |
+| `dir`                              | The directory inside the project base directory to run the gradle or maven upgrade in                                                                                   |
+| `baseBranch`                       | The git branch to checkout and that the pull request will target                                                                                                        |
+| `options.gitCommitExtraArgs`       | List of additional git commit arguments                                                                                                                                 |
+| `options.allowPreRelease`          | Boolean: `true` will get the latest Maven/Gradle version even if it's a pre-release. Default is `false`.                                                                |
+| `options.labels`                   | Optional list of label (names) that will be added to the pull request.                                                                                                  |
+| `options.ignoreClosedPullRequests` | Boolean: `true` will recreate the pull request if a closed pull request with the same branch name exists. `false` will not create the pull request. Default is `false`. |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -113,22 +113,25 @@ wrapperUpgrade {
             dir = ...
             options {
                 gitCommitExtraArgs = [...]
-                allowPreRelease = [...]
+                allowPreRelease = true
+                labels = ['dependencies']
+                ignoreExistingClosedPr = true
             }
         }
     }
 }
 ```
 
-| Field                        | description                                                                                                                                                      |
-|:-----------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`                       | A name identifying the upgrade, it can be different from the project name, for example when you need to upgrade multiple gradle projects in the same git project |
-| `repo`                       | The GitHub repository to clone, format 'organization/project`                                                                                                    |
-| `dir`                        | The directory inside the project base directory to run the gradle or maven upgrade in                                                                            |
-| `baseBranch`                 | The git branch to checkout and that the pull request will target                                                                                                 |
-| `options.gitCommitExtraArgs` | List of additional git commit arguments                                                                                                                          |
-| `options.allowPreRelease`    | Boolean: true will get the latest Maven/Gradle version even if it's a pre-release. Default is false.                                                             |
-| `options.labels`             | Optional list of label (names) that will be added to the PR.                                                                                                     |
+| Field                            | description                                                                                                                                                      |
+|:---------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                           | A name identifying the upgrade, it can be different from the project name, for example when you need to upgrade multiple gradle projects in the same git project |
+| `repo`                           | The GitHub repository to clone, format 'organization/project`                                                                                                    |
+| `dir`                            | The directory inside the project base directory to run the gradle or maven upgrade in                                                                            |
+| `baseBranch`                     | The git branch to checkout and that the pull request will target                                                                                                 |
+| `options.gitCommitExtraArgs`     | List of additional git commit arguments                                                                                                                          |
+| `options.allowPreRelease`        | Boolean: true will get the latest Maven/Gradle version even if it's a pre-release. Default is false.                                                             |
+| `options.labels`                 | Optional list of label (names) that will be added to the PR.                                                                                                     |
+| `options.ignoreExistingClosedPr` | Boolean: true will recreate the PR if a closed PR with the same branch name exists. false will not create the PR. Default is false.                              |
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     testImplementation gradleTestKit()
     testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
+    testImplementation 'net.bytebuddy:byte-buddy:1.15.10'
 }
 
 wrapperUpgrade {

--- a/src/main/java/org/gradle/wrapperupgrade/PullRequestUtils.java
+++ b/src/main/java/org/gradle/wrapperupgrade/PullRequestUtils.java
@@ -35,8 +35,8 @@ public class PullRequestUtils {
             .collect(Collectors.toSet());
     }
 
-    boolean prExists(String branch, boolean ignoreExistingClosedPr) {
-        Predicate<GHPullRequest> predicate = ignoreExistingClosedPr ? p -> branch.equals(p.getHead().getRef()) && p.getState() == GHIssueState.OPEN :
+    boolean prExists(String branch, boolean ignoreClosedPRs) {
+        Predicate<GHPullRequest> predicate = ignoreClosedPRs ? p -> branch.equals(p.getHead().getRef()) && p.getState() == GHIssueState.OPEN :
             p -> branch.equals(p.getHead().getRef());
         return pullRequests.stream().anyMatch(predicate);
     }

--- a/src/main/java/org/gradle/wrapperupgrade/PullRequestUtils.java
+++ b/src/main/java/org/gradle/wrapperupgrade/PullRequestUtils.java
@@ -1,0 +1,44 @@
+package org.gradle.wrapperupgrade;
+
+import org.gradle.util.internal.VersionNumber;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHPullRequest;
+
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class PullRequestUtils {
+
+    private static final String BRANCH_PREFIX = "wrapperbot/%s/%s-wrapper-";
+    private final Set<GHPullRequest> pullRequests;
+
+    PullRequestUtils(Set<GHPullRequest> pullRequests) {
+        this.pullRequests = pullRequests;
+    }
+
+    static String branchPrefix(String project, String buildTool) {
+        return String.format(BRANCH_PREFIX, project, buildTool.toLowerCase());
+    }
+
+    Set<GHPullRequest> pullRequestsToClose(String project, String buildTool, String latestBuildToolVersion) {
+        VersionNumber latest = VersionNumber.parse(latestBuildToolVersion);
+        return pullRequests.stream()
+                .filter(p -> p.getState() != GHIssueState.CLOSED)
+                .filter(p -> {
+                    String branch = p.getHead().getRef();
+                    String prefix = branchPrefix(project, buildTool);
+                    int index = branch.lastIndexOf(prefix);
+                    return index == 0 && latest.compareTo(VersionNumber.parse(branch.substring(prefix.length()))) > 0;
+                }
+            )
+            .collect(Collectors.toSet());
+    }
+
+    boolean prExists(String branch, boolean ignoreExistingClosedPr) {
+        Predicate<GHPullRequest> predicate = ignoreExistingClosedPr ? p -> branch.equals(p.getHead().getRef()) && p.getState() == GHIssueState.OPEN :
+            p -> branch.equals(p.getHead().getRef());
+        return pullRequests.stream().anyMatch(predicate);
+    }
+
+}

--- a/src/main/java/org/gradle/wrapperupgrade/PullRequestUtils.java
+++ b/src/main/java/org/gradle/wrapperupgrade/PullRequestUtils.java
@@ -5,7 +5,6 @@ import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHPullRequest;
 
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class PullRequestUtils {
@@ -35,10 +34,16 @@ public class PullRequestUtils {
             .collect(Collectors.toSet());
     }
 
-    boolean prExists(String branch, boolean ignoreClosedPRs) {
-        Predicate<GHPullRequest> predicate = ignoreClosedPRs ? p -> branch.equals(p.getHead().getRef()) && p.getState() == GHIssueState.OPEN :
-            p -> branch.equals(p.getHead().getRef());
-        return pullRequests.stream().anyMatch(predicate);
+    boolean openPrExists(String branch) {
+        return prExists(branch, GHIssueState.OPEN);
+    }
+
+    boolean closedPrExists(String branch) {
+        return prExists(branch, GHIssueState.CLOSED);
+    }
+
+    private boolean prExists(String branch, GHIssueState state) {
+        return pullRequests.stream().anyMatch(p -> branch.equals(p.getHead().getRef()) && p.getState() == state);
     }
 
 }

--- a/src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java
+++ b/src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java
@@ -63,16 +63,16 @@ public abstract class UpgradeWrapper extends DefaultTask {
     void upgrade() throws IOException {
         GitHub gitHub = createGitHub();
         boolean allowPreRelease = upgrade.getOptions().getAllowPreRelease().orElse(Boolean.FALSE).get();
-        boolean ignoreClosedPRs = upgrade.getOptions().getIgnoreClosedPullRequests().orElse(Boolean.FALSE).get();
-        Params params = Params.create(upgrade, buildToolStrategy, allowPreRelease, layout.getProjectDirectory(), getCheckoutDir().get(), gitHub, ignoreClosedPRs, execOperations);
+        boolean recreateClosedPRs = upgrade.getOptions().getRecreateClosedPullRequests().orElse(Boolean.FALSE).get();
+        Params params = Params.create(upgrade, buildToolStrategy, allowPreRelease, layout.getProjectDirectory(), getCheckoutDir().get(), gitHub, recreateClosedPRs, execOperations);
 
         PullRequestUtils utils = new PullRequestUtils(pullRequests(params));
-        if (!utils.prExists(params.prBranch, params.ignoreClosedPRs)) {
+        if (!utils.prExists(params.prBranch, params.recreateClosedPRs)) {
             Set<GHPullRequest> pullRequestsToClose = utils.pullRequestsToClose(params.project, buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version);
             createPrIfWrapperUpgradeAvailable(params, pullRequestsToClose);
         } else {
             String message = "An opened or closed pull request from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'";
-            if (params.ignoreClosedPRs) {
+            if (params.recreateClosedPRs) {
                 message = "An opened pull request from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'";
             }
             getLogger().lifecycle(String.format(message,
@@ -244,7 +244,7 @@ public abstract class UpgradeWrapper extends DefaultTask {
         private final VersionInfo latestBuildToolVersion;
         private final VersionInfo usedBuildToolVersion;
         private final List<String> gitCommitExtraArgs;
-        private final boolean ignoreClosedPRs;
+        private final boolean recreateClosedPRs;
         private final GitHub gitHub;
 
         private Params(
@@ -258,7 +258,7 @@ public abstract class UpgradeWrapper extends DefaultTask {
             VersionInfo latestBuildToolVersion,
             VersionInfo usedBuildToolVersion,
             List<String> gitCommitExtraArgs,
-            boolean ignoreClosedPRs,
+            boolean recreateClosedPRs,
             GitHub gitHub
         ) {
             this.project = project;
@@ -272,7 +272,7 @@ public abstract class UpgradeWrapper extends DefaultTask {
             this.usedBuildToolVersion = usedBuildToolVersion;
             this.gitCommitExtraArgs = gitCommitExtraArgs;
             this.gitHub = gitHub;
-            this.ignoreClosedPRs = ignoreClosedPRs;
+            this.recreateClosedPRs = recreateClosedPRs;
         }
 
         private static Params create

--- a/src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java
+++ b/src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java
@@ -63,7 +63,7 @@ public abstract class UpgradeWrapper extends DefaultTask {
     void upgrade() throws IOException {
         GitHub gitHub = createGitHub();
         boolean allowPreRelease = upgrade.getOptions().getAllowPreRelease().orElse(Boolean.FALSE).get();
-        boolean ignoreClosedPRs = upgrade.getOptions().getIgnoreClosedPRs().orElse(Boolean.FALSE).get();
+        boolean ignoreClosedPRs = upgrade.getOptions().getIgnoreClosedPullRequests().orElse(Boolean.FALSE).get();
         Params params = Params.create(upgrade, buildToolStrategy, allowPreRelease, layout.getProjectDirectory(), getCheckoutDir().get(), gitHub, ignoreClosedPRs, execOperations);
 
         PullRequestUtils utils = new PullRequestUtils(pullRequests(params));
@@ -71,9 +71,9 @@ public abstract class UpgradeWrapper extends DefaultTask {
             Set<GHPullRequest> pullRequestsToClose = utils.pullRequestsToClose(params.project, buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version);
             createPrIfWrapperUpgradeAvailable(params, pullRequestsToClose);
         } else {
-            String message = "An opened or closed PR from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'";
+            String message = "An opened or closed pull request from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'";
             if (params.ignoreClosedPRs) {
-                message = "An opened PR from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'";
+                message = "An opened pull request from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'";
             }
             getLogger().lifecycle(String.format(message,
                 params.prBranch, buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version, params.project));
@@ -101,7 +101,7 @@ public abstract class UpgradeWrapper extends DefaultTask {
             createPr(params);
             closePullRequests(params, prsToClose);
         } else {
-            getLogger().lifecycle(String.format("No PR created to upgrade %s Wrapper to %s since already on latest version for project '%s'",
+            getLogger().lifecycle(String.format("No pull request created to upgrade %s Wrapper to %s since already on latest version for project '%s'",
                 buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version, params.project));
         }
     }
@@ -179,10 +179,10 @@ public abstract class UpgradeWrapper extends DefaultTask {
             if (!labels.isEmpty()) {
                 pr.addLabels(labels.toArray(new String[0]));
             }
-            getLogger().lifecycle(String.format("PR '%s' created at %s to upgrade %s Wrapper to %s for project '%s'",
+            getLogger().lifecycle(String.format("Pull request '%s' created at %s to upgrade %s Wrapper to %s for project '%s'",
                 params.prBranch, pr.getHtmlUrl(), buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version, params.project));
         } else {
-            getLogger().lifecycle(String.format("Dry run: Skipping creation of PR '%s' that would upgrade %s Wrapper to %s for project '%s'",
+            getLogger().lifecycle(String.format("Dry run: Skipping creation of pull request '%s' that would upgrade %s Wrapper to %s for project '%s'",
                 params.prBranch, buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version, params.project));
         }
     }
@@ -199,18 +199,18 @@ public abstract class UpgradeWrapper extends DefaultTask {
             try {
                 closePullRequest(params, pr);
             } catch (IOException e) {
-                getLogger().warn(String.format("Error deleting PR #%s", pr.getId()), e);
+                getLogger().warn(String.format("Error closing pull request #%s", pr.getId()), e);
             }
         }
     }
 
     private void closePullRequest(Params params, GHPullRequest pr) throws IOException {
         if (!isDryRun()) {
-            getLogger().lifecycle(String.format("PR #'%s' on project '%s' has been closed because target %s Wrapper version is older than %s",
+            getLogger().lifecycle(String.format("Pull request #%s on project '%s' has been closed because target %s Wrapper version is older than %s",
                 pr.getNumber(), params.project, buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version));
             pr.close();
         } else {
-            getLogger().lifecycle(String.format("Dry run: Skipping closure of PR #%s on project '%s' because target %s Wrapper version is older than %s",
+            getLogger().lifecycle(String.format("Dry run: Skipping closure of pull request #%s on project '%s' because target %s Wrapper version is older than %s",
                 pr.getNumber(), params.project, buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version));
         }
     }

--- a/src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java
+++ b/src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java
@@ -71,7 +71,7 @@ public abstract class UpgradeWrapper extends DefaultTask {
             Set<GHPullRequest> pullRequestsToClose = utils.pullRequestsToClose(params.project, buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version);
             createPrIfWrapperUpgradeAvailable(params, pullRequestsToClose);
         } else {
-            String message = "A PR from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'";
+            String message = "An opened or closed PR from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'";
             if (params.ignoreExistingClosedPr) {
                 message = "An opened PR from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'";
             }

--- a/src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java
+++ b/src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java
@@ -52,12 +52,14 @@ public abstract class WrapperUpgradeDomainObject {
         private final ListProperty<String> gitCommitExtraArgs;
         private final Property<Boolean> allowPreRelease;
         private final ListProperty<String> labels;
+        private final Property<Boolean> ignoreExistingClosedPr;
 
         @Inject
         public Options(ObjectFactory objects) {
             this.gitCommitExtraArgs = objects.listProperty(String.class);
             this.allowPreRelease = objects.property(Boolean.class);
             this.labels = objects.listProperty(String.class);
+            this.ignoreExistingClosedPr = objects.property(Boolean.class);
         }
 
         public ListProperty<String> getGitCommitExtraArgs() {
@@ -70,6 +72,10 @@ public abstract class WrapperUpgradeDomainObject {
 
          public ListProperty<String> getLabels() {
             return labels;
+        }
+
+        public Property<Boolean> getIgnoreExistingClosedPr() {
+            return ignoreExistingClosedPr;
         }
     }
 

--- a/src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java
+++ b/src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java
@@ -52,14 +52,14 @@ public abstract class WrapperUpgradeDomainObject {
         private final ListProperty<String> gitCommitExtraArgs;
         private final Property<Boolean> allowPreRelease;
         private final ListProperty<String> labels;
-        private final Property<Boolean> ignoreClosedPRs;
+        private final Property<Boolean> ignoreClosedPullRequests;
 
         @Inject
         public Options(ObjectFactory objects) {
             this.gitCommitExtraArgs = objects.listProperty(String.class);
             this.allowPreRelease = objects.property(Boolean.class);
             this.labels = objects.listProperty(String.class);
-            this.ignoreClosedPRs = objects.property(Boolean.class);
+            this.ignoreClosedPullRequests = objects.property(Boolean.class);
         }
 
         public ListProperty<String> getGitCommitExtraArgs() {
@@ -74,8 +74,8 @@ public abstract class WrapperUpgradeDomainObject {
             return labels;
         }
 
-        public Property<Boolean> getIgnoreClosedPRs() {
-            return ignoreClosedPRs;
+        public Property<Boolean> getIgnoreClosedPullRequests() {
+            return ignoreClosedPullRequests;
         }
     }
 

--- a/src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java
+++ b/src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java
@@ -52,14 +52,14 @@ public abstract class WrapperUpgradeDomainObject {
         private final ListProperty<String> gitCommitExtraArgs;
         private final Property<Boolean> allowPreRelease;
         private final ListProperty<String> labels;
-        private final Property<Boolean> ignoreExistingClosedPr;
+        private final Property<Boolean> ignoreClosedPRs;
 
         @Inject
         public Options(ObjectFactory objects) {
             this.gitCommitExtraArgs = objects.listProperty(String.class);
             this.allowPreRelease = objects.property(Boolean.class);
             this.labels = objects.listProperty(String.class);
-            this.ignoreExistingClosedPr = objects.property(Boolean.class);
+            this.ignoreClosedPRs = objects.property(Boolean.class);
         }
 
         public ListProperty<String> getGitCommitExtraArgs() {
@@ -74,8 +74,8 @@ public abstract class WrapperUpgradeDomainObject {
             return labels;
         }
 
-        public Property<Boolean> getIgnoreExistingClosedPr() {
-            return ignoreExistingClosedPr;
+        public Property<Boolean> getIgnoreClosedPRs() {
+            return ignoreClosedPRs;
         }
     }
 

--- a/src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java
+++ b/src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java
@@ -52,14 +52,14 @@ public abstract class WrapperUpgradeDomainObject {
         private final ListProperty<String> gitCommitExtraArgs;
         private final Property<Boolean> allowPreRelease;
         private final ListProperty<String> labels;
-        private final Property<Boolean> ignoreClosedPullRequests;
+        private final Property<Boolean> recreateClosedPullRequests;
 
         @Inject
         public Options(ObjectFactory objects) {
             this.gitCommitExtraArgs = objects.listProperty(String.class);
             this.allowPreRelease = objects.property(Boolean.class);
             this.labels = objects.listProperty(String.class);
-            this.ignoreClosedPullRequests = objects.property(Boolean.class);
+            this.recreateClosedPullRequests = objects.property(Boolean.class);
         }
 
         public ListProperty<String> getGitCommitExtraArgs() {
@@ -74,8 +74,8 @@ public abstract class WrapperUpgradeDomainObject {
             return labels;
         }
 
-        public Property<Boolean> getIgnoreClosedPullRequests() {
-            return ignoreClosedPullRequests;
+        public Property<Boolean> getRecreateClosedPullRequests() {
+            return recreateClosedPullRequests;
         }
     }
 

--- a/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
@@ -48,7 +48,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
                         baseBranch = 'func-test-do-not-delete'
                         dir = 'samples/gradle'
                         options {
-                            ignoreClosedPRs = true
+                            ignoreClosedPullRequests = true
                             allowPreRelease = ${allowPreRelease}
                             labels = ["dependencies", "java"]
                         }
@@ -99,7 +99,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
         result.task(':upgradeGradleWrapperAll').outcome == SUCCESS
 
         and:
-        result.output.contains "No PR created to upgrade Gradle Wrapper to 8.2-rc-2 since already on latest version for project 'junit-func-test'"
+        result.output.contains "No pull request created to upgrade Gradle Wrapper to 8.2-rc-2 since already on latest version for project 'junit-func-test'"
     }
 
     def "upgrade wrapper on wrapper-upgrade-gradle-plugin with dry run"() {
@@ -115,7 +115,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
         result.task(':upgradeGradleWrapperAll').outcome == SUCCESS
 
         and:
-        result.output.contains("Dry run: Skipping creation of PR 'wrapperbot/wrapper-upgrade-gradle-plugin-for-func-tests/gradle-wrapper-${latestGradleVersion}")
+        result.output.contains("Dry run: Skipping creation of pull request 'wrapperbot/wrapper-upgrade-gradle-plugin-for-func-tests/gradle-wrapper-${latestGradleVersion}")
 
         and:
         def gitDir = new File(testProjectDir, 'build/git-clones/wrapper-upgrade-gradle-plugin-for-func-tests/samples/gradle')
@@ -189,7 +189,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
         result.task(':upgradeGradleWrapperAll').outcome == SUCCESS
 
         and:
-        result.output.contains("Dry run: Skipping creation of PR 'wrapperbot/wrapper-upgrade-gradle-plugin-for-func-tests/gradle-wrapper-${latestGradleVersion}")
+        result.output.contains("Dry run: Skipping creation of pull request 'wrapperbot/wrapper-upgrade-gradle-plugin-for-func-tests/gradle-wrapper-${latestGradleVersion}")
 
         and:
         def gitDir = new File(testProjectDir, 'build/git-clones/wrapper-upgrade-gradle-plugin-for-func-tests/samples/gradle')
@@ -225,7 +225,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
         result.task(':upgradeGradleWrapperAll').outcome == SUCCESS
 
         and:
-        result.output.contains("Dry run: Skipping creation of PR 'wrapperbot/wrapper-upgrade-gradle-plugin-for-func-tests/gradle-wrapper-${latestGradleVersion}")
+        result.output.contains("Dry run: Skipping creation of pull request 'wrapperbot/wrapper-upgrade-gradle-plugin-for-func-tests/gradle-wrapper-${latestGradleVersion}")
         result.output.contains('Configuration cache entry stored.')
 
         when:
@@ -240,7 +240,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
         result.task(':upgradeGradleWrapperAll').outcome == SUCCESS
 
         and:
-        result.output.contains("Dry run: Skipping creation of PR 'wrapperbot/wrapper-upgrade-gradle-plugin-for-func-tests/gradle-wrapper-${latestGradleVersion}")
+        result.output.contains("Dry run: Skipping creation of pull request 'wrapperbot/wrapper-upgrade-gradle-plugin-for-func-tests/gradle-wrapper-${latestGradleVersion}")
         result.output.contains('Reusing configuration cache.')
     }
 
@@ -278,7 +278,7 @@ wrapperUpgrade {
         result.task(':upgradeGradleWrapperAll').outcome == SUCCESS
 
         and:
-        result.output.contains("Dry run: Skipping creation of PR 'wrapperbot/wrapper-upgrade-gradle-plugin-for-func-tests/gradle-wrapper-${latestGradleVersion}")
+        result.output.contains("Dry run: Skipping creation of pull request 'wrapperbot/wrapper-upgrade-gradle-plugin-for-func-tests/gradle-wrapper-${latestGradleVersion}")
 
         and:
         def gitDir = new File(testProjectDir, 'build/git-clones/wrapper-upgrade-gradle-plugin-for-func-tests/samples/gradle')

--- a/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
@@ -48,7 +48,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
                         baseBranch = 'func-test-do-not-delete'
                         dir = 'samples/gradle'
                         options {
-                            ignoreExistingClosedPr = true
+                            ignoreClosedPRs = true
                             allowPreRelease = ${allowPreRelease}
                             labels = ["dependencies", "java"]
                         }

--- a/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
@@ -48,7 +48,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
                         baseBranch = 'func-test-do-not-delete'
                         dir = 'samples/gradle'
                         options {
-                            ignoreClosedPullRequests = true
+                            recreateClosedPullRequests = true
                             allowPreRelease = ${allowPreRelease}
                             labels = ["dependencies", "java"]
                         }

--- a/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
@@ -48,6 +48,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
                         baseBranch = 'func-test-do-not-delete'
                         dir = 'samples/gradle'
                         options {
+                            ignoreExistingClosedPr = true
                             allowPreRelease = ${allowPreRelease}
                             labels = ["dependencies", "java"]
                         }

--- a/src/test/groovy/org/gradle/wrapperupgrade/MavenWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/MavenWrapperUpgradePluginFuncTest.groovy
@@ -42,7 +42,7 @@ wrapperUpgrade {
             baseBranch = 'func-test-do-not-delete'
             dir = 'samples/maven'
             options {
-                ignoreClosedPRs = true
+                ignoreClosedPullRequests = true
                 allowPreRelease = ${allowPreRelease}
                 labels = ["dependencies", "java"]
             }
@@ -64,7 +64,7 @@ wrapperUpgrade {
         result.task(':upgradeMavenWrapperAll').outcome == SUCCESS
 
         and:
-        result.output.contains("Dry run: Skipping creation of PR 'wrapperbot/wrapper-upgrade-gradle-plugin-for-func-tests/maven-wrapper-${latestMavenVersion}")
+        result.output.contains("Dry run: Skipping creation of pull request 'wrapperbot/wrapper-upgrade-gradle-plugin-for-func-tests/maven-wrapper-${latestMavenVersion}")
 
         and:
         def gitDir = new File(testProjectDir, 'build/git-clones/wrapper-upgrade-gradle-plugin-for-func-tests/samples/maven')

--- a/src/test/groovy/org/gradle/wrapperupgrade/MavenWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/MavenWrapperUpgradePluginFuncTest.groovy
@@ -42,7 +42,7 @@ wrapperUpgrade {
             baseBranch = 'func-test-do-not-delete'
             dir = 'samples/maven'
             options {
-                ignoreExistingClosedPr = true
+                ignoreClosedPRs = true
                 allowPreRelease = ${allowPreRelease}
                 labels = ["dependencies", "java"]
             }

--- a/src/test/groovy/org/gradle/wrapperupgrade/MavenWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/MavenWrapperUpgradePluginFuncTest.groovy
@@ -42,7 +42,7 @@ wrapperUpgrade {
             baseBranch = 'func-test-do-not-delete'
             dir = 'samples/maven'
             options {
-                ignoreClosedPullRequests = true
+                recreateClosedPullRequests = true
                 allowPreRelease = ${allowPreRelease}
                 labels = ["dependencies", "java"]
             }

--- a/src/test/groovy/org/gradle/wrapperupgrade/MavenWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/MavenWrapperUpgradePluginFuncTest.groovy
@@ -42,6 +42,7 @@ wrapperUpgrade {
             baseBranch = 'func-test-do-not-delete'
             dir = 'samples/maven'
             options {
+                ignoreExistingClosedPr = true
                 allowPreRelease = ${allowPreRelease}
                 labels = ["dependencies", "java"]
             }

--- a/src/test/groovy/org/gradle/wrapperupgrade/PullRequestUtilsTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/PullRequestUtilsTest.groovy
@@ -1,0 +1,71 @@
+package org.gradle.wrapperupgrade
+
+import org.kohsuke.github.GHCommitPointer
+import org.kohsuke.github.GHIssueState
+import org.kohsuke.github.GHPullRequest
+import spock.lang.Specification
+
+class PullRequestUtilsTest extends Specification {
+
+    def "pr exists"() {
+        given:
+        def pullRequests = [
+            stub('somebranch', GHIssueState.OPEN),
+            stub('someotherbranch', GHIssueState.CLOSED),
+            stub('wrapperbot/someproj/gradle-wrapper-8.10', GHIssueState.OPEN),
+            stub('wrapperbot/someproj/gradle-wrapper-8.10', GHIssueState.CLOSED),
+            stub('wrapperbot/someproj/gradle-wrapper-8.11.1', status)
+        ] as Set
+
+        def utils = new PullRequestUtils(pullRequests)
+
+        when:
+        def result = utils.prExists('wrapperbot/someproj/gradle-wrapper-8.11.1', ignoreExistingClosed)
+
+        then:
+        result == exists
+
+        where:
+        ignoreExistingClosed | status              | exists
+        true                 | GHIssueState.OPEN   | true
+        true                 | GHIssueState.CLOSED | false
+        false                | GHIssueState.OPEN   | true
+        false                | GHIssueState.CLOSED | true
+    }
+
+    def "pull requests to close"() {
+        given:
+        def pullRequests = [
+            stub('somebranch', GHIssueState.OPEN),
+            stub('someotherbranch', GHIssueState.CLOSED),
+            stub('wrapperbot/someproj/gradle-wrapper-8.9', GHIssueState.OPEN),
+            stub('wrapperbot/someproj/gradle-wrapper-8.10', GHIssueState.CLOSED),
+            stub('wrapperbot/someproj/gradle-wrapper-8.11.1', GHIssueState.OPEN)
+        ] as Set
+
+        def utils = new PullRequestUtils(pullRequests)
+
+        when:
+        def result = utils.pullRequestsToClose('someproj', 'gradle', latestBuildToolVersion)
+
+        then:
+        result.collect { it.head.ref } as Set == toClose as Set
+
+        where:
+        latestBuildToolVersion | toClose
+        '7.13'                 | []
+        '8.10'                 | ['wrapperbot/someproj/gradle-wrapper-8.9']
+        '8.11.1'               | ['wrapperbot/someproj/gradle-wrapper-8.9']
+        '8.11.2'               | ['wrapperbot/someproj/gradle-wrapper-8.11.1', 'wrapperbot/someproj/gradle-wrapper-8.9']
+        '8.12'                 | ['wrapperbot/someproj/gradle-wrapper-8.11.1', 'wrapperbot/someproj/gradle-wrapper-8.9']
+    }
+
+    private GHPullRequest stub(String branchName, GHIssueState state) {
+        def pr = Stub(GHPullRequest)
+        def pointer = Stub(GHCommitPointer)
+        pointer.getRef() >> branchName
+        pr.getHead() >> pointer
+        pr.getState() >> state
+        return pr
+    }
+}

--- a/src/test/groovy/org/gradle/wrapperupgrade/PullRequestUtilsTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/PullRequestUtilsTest.groovy
@@ -7,40 +7,58 @@ import spock.lang.Specification
 
 class PullRequestUtilsTest extends Specification {
 
-    def "pr exists"() {
+    def "open pr exists"() {
         given:
         def pullRequests = [
-            stub('somebranch', GHIssueState.OPEN),
-            stub('someotherbranch', GHIssueState.CLOSED),
-            stub('wrapperbot/someproj/gradle-wrapper-8.10', GHIssueState.OPEN),
-            stub('wrapperbot/someproj/gradle-wrapper-8.10', GHIssueState.CLOSED),
-            stub('wrapperbot/someproj/gradle-wrapper-8.11.1', status)
+                stub('wrapperbot/someproj/gradle-wrapper-8.10', GHIssueState.CLOSED),
+                stub('wrapperbot/someproj/gradle-wrapper-8.11.1', GHIssueState.OPEN),
+                stub('wrapperbot/someproj/gradle-wrapper-8.11.1', GHIssueState.CLOSED)
         ] as Set
 
         def utils = new PullRequestUtils(pullRequests)
 
         when:
-        def result = utils.prExists('wrapperbot/someproj/gradle-wrapper-8.11.1', ignoreExistingClosed)
+        def result = utils.openPrExists(branch)
 
         then:
         result == exists
 
         where:
-        ignoreExistingClosed | status              | exists
-        true                 | GHIssueState.OPEN   | true
-        true                 | GHIssueState.CLOSED | false
-        false                | GHIssueState.OPEN   | true
-        false                | GHIssueState.CLOSED | true
+        branch                                      | exists
+        'wrapperbot/someproj/gradle-wrapper-8.11.1' | true
+        'wrapperbot/someproj/gradle-wrapper-8.10'   | false
+    }
+
+    def "closed pr exists"() {
+        given:
+        def pullRequests = [
+                stub('wrapperbot/someproj/gradle-wrapper-8.10', GHIssueState.OPEN),
+                stub('wrapperbot/someproj/gradle-wrapper-8.11.1', GHIssueState.OPEN),
+                stub('wrapperbot/someproj/gradle-wrapper-8.11.1', GHIssueState.CLOSED)
+        ] as Set
+
+        def utils = new PullRequestUtils(pullRequests)
+
+        when:
+        def result = utils.closedPrExists(branch)
+
+        then:
+        result == exists
+
+        where:
+        branch                                      | exists
+        'wrapperbot/someproj/gradle-wrapper-8.11.1' | true
+        'wrapperbot/someproj/gradle-wrapper-8.10'   | false
     }
 
     def "pull requests to close"() {
         given:
         def pullRequests = [
-            stub('somebranch', GHIssueState.OPEN),
-            stub('someotherbranch', GHIssueState.CLOSED),
-            stub('wrapperbot/someproj/gradle-wrapper-8.9', GHIssueState.OPEN),
-            stub('wrapperbot/someproj/gradle-wrapper-8.10', GHIssueState.CLOSED),
-            stub('wrapperbot/someproj/gradle-wrapper-8.11.1', GHIssueState.OPEN)
+                stub('somebranch', GHIssueState.OPEN),
+                stub('someotherbranch', GHIssueState.CLOSED),
+                stub('wrapperbot/someproj/gradle-wrapper-8.9', GHIssueState.OPEN),
+                stub('wrapperbot/someproj/gradle-wrapper-8.10', GHIssueState.CLOSED),
+                stub('wrapperbot/someproj/gradle-wrapper-8.11.1', GHIssueState.OPEN)
         ] as Set
 
         def utils = new PullRequestUtils(pullRequests)


### PR DESCRIPTION
Fix #252
- Do not execute the update if a branch with the same version already exists
- Do not create the PR if a closed one for the same version already exists
PRs can be recreated by setting `options.recreateClosedPullRequests` to true.

Fix #211 
- Close existing open PR targeting older versions


