### PR TITLE
Remove unnecessary open pr check

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ wrapperUpgrade {
                 gitCommitExtraArgs = [...]
                 allowPreRelease = true
                 labels = ['dependencies']
-                recreateClosedPullRequests = true
+                recreateClosedPullRequest = true
             }
         }
     }
@@ -131,7 +131,7 @@ wrapperUpgrade {
 | `options.gitCommitExtraArgs`         | List of additional git commit arguments                                                                                                                                   |
 | `options.allowPreRelease`            | Boolean: `true` will get the latest Maven/Gradle version even if it's a pre-release. Default is `false`.                                                                  |
 | `options.labels`                     | Optional list of label (names) that will be added to the pull request.                                                                                                    |
-| `options.recreateClosedPullRequests` | Boolean: `true` will recreate the pull request if a closed pull request with the same branch name exists. `false` will not recreate the pull request. Default is `false`. |
+| `options.recreateClosedPullRequest`  | Boolean: `true` will recreate the pull request if a closed pull request with the same branch name exists. `false` will not recreate the pull request. Default is `false`. |
 
 ## License
 

--- a/src/main/java/org/gradle/wrapperupgrade/PullRequestUtils.java
+++ b/src/main/java/org/gradle/wrapperupgrade/PullRequestUtils.java
@@ -34,16 +34,7 @@ public class PullRequestUtils {
             .collect(Collectors.toSet());
     }
 
-    boolean openPrExists(String branch) {
-        return prExists(branch, GHIssueState.OPEN);
-    }
-
     boolean closedPrExists(String branch) {
-        return prExists(branch, GHIssueState.CLOSED);
+        return pullRequests.stream().anyMatch(p -> branch.equals(p.getHead().getRef()) && p.getState() == GHIssueState.CLOSED);
     }
-
-    private boolean prExists(String branch, GHIssueState state) {
-        return pullRequests.stream().anyMatch(p -> branch.equals(p.getHead().getRef()) && p.getState() == state);
-    }
-
 }

--- a/src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java
+++ b/src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java
@@ -70,8 +70,8 @@ public abstract class UpgradeWrapper extends DefaultTask {
     void upgrade() throws IOException {
         GitHub gitHub = createGitHub();
         boolean allowPreRelease = upgrade.getOptions().getAllowPreRelease().orElse(Boolean.FALSE).get();
-        boolean recreateClosedPRs = upgrade.getOptions().getRecreateClosedPullRequests().orElse(Boolean.FALSE).get();
-        Params params = Params.create(upgrade, buildToolStrategy, allowPreRelease, layout.getProjectDirectory(), getCheckoutDir().get(), gitHub, recreateClosedPRs, execOperations);
+        boolean recreateClosedPr = upgrade.getOptions().getRecreateClosedPullRequest().orElse(Boolean.FALSE).get();
+        Params params = Params.create(upgrade, buildToolStrategy, allowPreRelease, layout.getProjectDirectory(), getCheckoutDir().get(), gitHub, recreateClosedPr, execOperations);
 
         if (branchExists(params)) {
             getLogger().lifecycle(String.format("GitHub branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'",
@@ -80,7 +80,7 @@ public abstract class UpgradeWrapper extends DefaultTask {
         }
         PullRequestUtils utils = new PullRequestUtils(pullRequests(params));
         if (utils.closedPrExists(params.prBranch) && !params.recreateClosedPRs) {
-            getLogger().lifecycle(String.format("A closed pull request from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'. Use `recreateClosedPullRequests` option to recreate it.",
+            getLogger().lifecycle(String.format("A closed pull request from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'. Use `recreateClosedPullRequest` option to recreate it.",
                 params.prBranch, buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version, params.project));
             return;
         }

--- a/src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java
+++ b/src/main/java/org/gradle/wrapperupgrade/UpgradeWrapper.java
@@ -79,11 +79,6 @@ public abstract class UpgradeWrapper extends DefaultTask {
             return;
         }
         PullRequestUtils utils = new PullRequestUtils(pullRequests(params));
-        if (utils.openPrExists(params.prBranch)) {
-            getLogger().lifecycle(String.format("An opened pull request from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'",
-                params.prBranch, buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version, params.project));
-            return;
-        }
         if (utils.closedPrExists(params.prBranch) && !params.recreateClosedPRs) {
             getLogger().lifecycle(String.format("A closed pull request from branch '%s' to upgrade %s Wrapper to %s already exists for project '%s'. Use `recreateClosedPullRequests` option to recreate it.",
                 params.prBranch, buildToolStrategy.buildToolName(), params.latestBuildToolVersion.version, params.project));

--- a/src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java
+++ b/src/main/java/org/gradle/wrapperupgrade/WrapperUpgradeDomainObject.java
@@ -52,14 +52,14 @@ public abstract class WrapperUpgradeDomainObject {
         private final ListProperty<String> gitCommitExtraArgs;
         private final Property<Boolean> allowPreRelease;
         private final ListProperty<String> labels;
-        private final Property<Boolean> recreateClosedPullRequests;
+        private final Property<Boolean> recreateClosedPullRequest;
 
         @Inject
         public Options(ObjectFactory objects) {
             this.gitCommitExtraArgs = objects.listProperty(String.class);
             this.allowPreRelease = objects.property(Boolean.class);
             this.labels = objects.listProperty(String.class);
-            this.recreateClosedPullRequests = objects.property(Boolean.class);
+            this.recreateClosedPullRequest = objects.property(Boolean.class);
         }
 
         public ListProperty<String> getGitCommitExtraArgs() {
@@ -74,8 +74,8 @@ public abstract class WrapperUpgradeDomainObject {
             return labels;
         }
 
-        public Property<Boolean> getRecreateClosedPullRequests() {
-            return recreateClosedPullRequests;
+        public Property<Boolean> getRecreateClosedPullRequest() {
+            return recreateClosedPullRequest;
         }
     }
 

--- a/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
@@ -48,7 +48,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
                         baseBranch = 'func-test-do-not-delete'
                         dir = 'samples/gradle'
                         options {
-                            recreateClosedPullRequests = true
+                            recreateClosedPullRequest = true
                             allowPreRelease = ${allowPreRelease}
                             labels = ["dependencies", "java"]
                         }

--- a/src/test/groovy/org/gradle/wrapperupgrade/MavenWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/MavenWrapperUpgradePluginFuncTest.groovy
@@ -42,7 +42,7 @@ wrapperUpgrade {
             baseBranch = 'func-test-do-not-delete'
             dir = 'samples/maven'
             options {
-                recreateClosedPullRequests = true
+                recreateClosedPullRequest = true
                 allowPreRelease = ${allowPreRelease}
                 labels = ["dependencies", "java"]
             }

--- a/src/test/groovy/org/gradle/wrapperupgrade/PullRequestUtilsTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/PullRequestUtilsTest.groovy
@@ -7,28 +7,6 @@ import spock.lang.Specification
 
 class PullRequestUtilsTest extends Specification {
 
-    def "open pr exists"() {
-        given:
-        def pullRequests = [
-                stub('wrapperbot/someproj/gradle-wrapper-8.10', GHIssueState.CLOSED),
-                stub('wrapperbot/someproj/gradle-wrapper-8.11.1', GHIssueState.OPEN),
-                stub('wrapperbot/someproj/gradle-wrapper-8.11.1', GHIssueState.CLOSED)
-        ] as Set
-
-        def utils = new PullRequestUtils(pullRequests)
-
-        when:
-        def result = utils.openPrExists(branch)
-
-        then:
-        result == exists
-
-        where:
-        branch                                      | exists
-        'wrapperbot/someproj/gradle-wrapper-8.11.1' | true
-        'wrapperbot/someproj/gradle-wrapper-8.10'   | false
-    }
-
     def "closed pr exists"() {
         given:
         def pullRequests = [


### PR DESCRIPTION
Follow up of https://github.com/gradle/wrapper-upgrade-gradle-plugin/pull/267#discussion_r1860874539
It's only possible to have an opened PR with a corresponding branch in GitHub.
Hence, checking for an existing branch is sufficient; no need to check for an opened PR afterward.

Also renames the  `recreateClosedPullRequests` to `recreateClosedPullRequest`