### PR TITLE
Updated GithubActions to use JDK 17

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -17,10 +17,10 @@ jobs:
         run: |
           git config --global user.name "bot-githubaction"
           git config --global user.email "bot-githubaction@gradle.com"
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 8
+        java-version: 17
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@v4
       with:

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -24,10 +24,10 @@ jobs:
           git_config_global: true
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
Updated GithubActions to use JDK 17. This is a required change, required by the [org.gradle.toolchains.foojay-resolver-convention](https://plugins.gradle.org/plugin/org.gradle.toolchains.foojay-resolver-convention) plugin v1.0.0. 

Without this, we either can't upgrade to the latest version of [org.gradle.toolchains.foojay-resolver-convention](https://plugins.gradle.org/plugin/org.gradle.toolchains.foojay-resolver-convention), or we have failing builds as seen on the example resolver upgrade PR: https://github.com/gradle/wrapper-upgrade-gradle-plugin/pull/299