### PR TITLE
Fix the integration test JDK used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,11 @@ tasks.withType(Test).configureEach {
     def testGradleVersion = findProperty('testGradleVersion') ?: GradleVersion.current().version
     systemProperty 'testContext.gradleVersion', testGradleVersion
     project.develocity.buildScan.value(identityPath.path + "#gradleVersion", testGradleVersion)
+
+    def javaHome = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(8)
+    }.map { it.metadata.installationPath }
+    systemProperty 'testContext.javaHome', javaHome.get().asFile.absolutePath
 }
 
 tasks.withType(Jar).configureEach {

--- a/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/GradleWrapperUpgradePluginFuncTest.groovy
@@ -66,6 +66,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
             .withProjectDir(testProjectDir)
             .withPluginClasspath()
             .withGradleVersion(GradleVersion.version('5.6.4').version)
+            .withEnvironment(System.getenv() + ["JAVA_HOME": determineJavaHome()])
             .withArguments('clean', 'upgradeGradleWrapperAll', '-DwrapperUpgrade.dryRun', '-DwrapperUpgrade.unsignedCommits')
             .buildAndFail()
 
@@ -94,6 +95,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
             .withProjectDir(testProjectDir)
             .withPluginClasspath()
             .withGradleVersion(determineGradleVersion().version)
+            .withEnvironment(System.getenv() + ["JAVA_HOME": determineJavaHome()])
             .withArguments('clean', 'upgradeGradleWrapperAll', '-DwrapperUpgrade.dryRun', '-DwrapperUpgrade.unsignedCommits')
             .build()
 
@@ -110,6 +112,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
             .withProjectDir(testProjectDir)
             .withPluginClasspath()
             .withGradleVersion(determineGradleVersion().version)
+            .withEnvironment(System.getenv() + ["JAVA_HOME": determineJavaHome()])
             .withArguments('clean', 'upgradeGradleWrapperAll', '-DwrapperUpgrade.dryRun', '-DwrapperUpgrade.unsignedCommits')
             .build()
 
@@ -184,6 +187,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
             .withProjectDir(testProjectDir)
             .withPluginClasspath()
             .withGradleVersion(determineGradleVersion().version)
+            .withEnvironment(System.getenv() + ["JAVA_HOME": determineJavaHome()])
             .withArguments('clean', 'upgradeGradleWrapperAll', '-DwrapperUpgrade.dryRun', '-DwrapperUpgrade.unsignedCommits')
             .build()
 
@@ -220,6 +224,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
             .withProjectDir(testProjectDir)
             .withPluginClasspath()
             .withGradleVersion(determineGradleVersion().version)
+            .withEnvironment(System.getenv() + ["JAVA_HOME": determineJavaHome()])
             .withArguments('clean', 'upgradeGradleWrapperAll', '--configuration-cache', '-DwrapperUpgrade.dryRun', '-DwrapperUpgrade.unsignedCommits')
             .build()
 
@@ -235,6 +240,7 @@ class GradleWrapperUpgradePluginFuncTest extends Specification {
             .withProjectDir(testProjectDir)
             .withPluginClasspath()
             .withGradleVersion(determineGradleVersion().version)
+            .withEnvironment(System.getenv() + ["JAVA_HOME": determineJavaHome()])
             .withArguments('clean', 'upgradeGradleWrapperAll', '--configuration-cache', '-DwrapperUpgrade.dryRun', '-DwrapperUpgrade.unsignedCommits')
             .build()
 
@@ -273,6 +279,7 @@ wrapperUpgrade {
             .withProjectDir(testProjectDir)
             .withPluginClasspath()
             .withGradleVersion(determineGradleVersion().version)
+            .withEnvironment(System.getenv() + ["JAVA_HOME": determineJavaHome()])
             .withArguments('clean', 'upgradeGradleWrapperAll', '-DwrapperUpgrade.dryRun', '-DwrapperUpgrade.unsignedCommits')
             .build()
 
@@ -293,6 +300,10 @@ wrapperUpgrade {
     private static GradleVersion determineGradleVersion() {
         def injectedGradleVersionString = System.getProperty('testContext.gradleVersion')
         injectedGradleVersionString ? GradleVersion.version(injectedGradleVersionString) : GradleVersion.current()
+    }
+
+    private static String determineJavaHome() {
+        return System.getProperty('testContext.javaHome')
     }
 
 }


### PR DESCRIPTION
Fix the integration test JDK used. Toolchains do affect which JDK is used for executing the test code; however, with integration tests, which Gradle TestKit tests are, the JDK used is whatever is the system default. This PR fixes the JDK to be used to JDK 8, as that's the lowest we want to support. This could also be extended to set different JDKs to run the integration tests against. 