### PR TITLE
Switched default test JDK to 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ tasks.withType(Test).configureEach {
     systemProperty 'testContext.gradleVersion', testGradleVersion
     project.develocity.buildScan.value(identityPath.path + "#gradleVersion", testGradleVersion)
 
-    def jdkMajorVersion = findProperty('testJdkMajorVersion') ?: '8'
+    def jdkMajorVersion = findProperty('testJdkMajorVersion') ?: '21'
     jvmArgumentProviders.add(
         new JdkHomeArgumentProvider(javaToolchains).tap {
             it.jdkMajorVersion = jdkMajorVersion


### PR DESCRIPTION
Should fix test failures like [these](https://ge.solutions-team.gradle.com/s/f74fsk43qknvc/tests/task/:test/details/org.gradle.wrapperupgrade.GradleWrapperUpgradePluginFuncTest/upgrade%20wrapper%20on%20wrapper-upgrade-gradle-plugin%20with%20dry%20run%20and%20optional%20Git%20arguments?focused-exception-line=0-15&top-execution=1).