### PR TITLE
Add Windows wrapper script support

### DIFF
--- a/src/main/java/org/gradle/wrapperupgrade/ExecUtils.java
+++ b/src/main/java/org/gradle/wrapperupgrade/ExecUtils.java
@@ -6,15 +6,16 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 
 final class ExecUtils {
 
     static void execGradleCmd(ExecOperations execOperations, Path workingDir, Object... args) {
-        execCmd(execOperations, workingDir, "./gradlew", args);
+        execCmd(execOperations, workingDir, gradleWrapperCommand(), args);
     }
 
     static void execMavenCmd(ExecOperations execOperations, Path workingDir, Object... args) {
-        execCmd(execOperations, workingDir, "./mvnw", args);
+        execCmd(execOperations, workingDir, mavenWrapperCommand(), args);
     }
 
     static void execGitCmd(ExecOperations execOperations, Path workingDir, Object... args) {
@@ -30,6 +31,26 @@ final class ExecUtils {
                 execSpec.workingDir(workingDir);
                 execSpec.commandLine(cmdLine);
             });
+    }
+
+    static String gradleWrapperCommand() {
+        return gradleWrapperCommand(System.getProperty("os.name", ""));
+    }
+
+    static String mavenWrapperCommand() {
+        return mavenWrapperCommand(System.getProperty("os.name", ""));
+    }
+
+    static String gradleWrapperCommand(String osName) {
+        return isWindows(osName) ? ".\\gradlew.bat" : "./gradlew";
+    }
+
+    static String mavenWrapperCommand(String osName) {
+        return isWindows(osName) ? ".\\mvnw.cmd" : "./mvnw";
+    }
+
+    private static boolean isWindows(String osName) {
+        return osName.toLowerCase(Locale.ROOT).contains("windows");
     }
 
     private ExecUtils() {

--- a/src/test/groovy/org/gradle/wrapperupgrade/ExecUtilsTest.groovy
+++ b/src/test/groovy/org/gradle/wrapperupgrade/ExecUtilsTest.groovy
@@ -1,0 +1,19 @@
+package org.gradle.wrapperupgrade
+
+import spock.lang.Specification
+
+class ExecUtilsTest extends Specification {
+
+    def "uses Windows wrapper scripts on Windows hosts"() {
+        expect:
+        ExecUtils.gradleWrapperCommand('Windows 11') == '.\\gradlew.bat'
+        ExecUtils.mavenWrapperCommand('Windows 11') == '.\\mvnw.cmd'
+    }
+
+    def "uses POSIX wrapper scripts on non-Windows hosts"() {
+        expect:
+        ExecUtils.gradleWrapperCommand('Linux') == './gradlew'
+        ExecUtils.mavenWrapperCommand('Mac OS X') == './mvnw'
+    }
+
+}


### PR DESCRIPTION
Implements #337.

This adds platform-aware wrapper command selection so the plugin invokes the correct wrapper script on Windows:

- Gradle: `.\\gradlew.bat` on Windows, `./gradlew` elsewhere
- Maven: `.\\mvnw.cmd` on Windows, `./mvnw` elsewhere

Also adds focused tests for Windows and non-Windows command selection.

Verification:
```text
./gradlew.bat test --tests org.gradle.wrapperupgrade.ExecUtilsTest -x java8Test --no-daemon --max-workers=1
```